### PR TITLE
remove duplicate variable names

### DIFF
--- a/src/main/java/gsn/http/restapi/RequestHandler.java
+++ b/src/main/java/gsn/http/restapi/RequestHandler.java
@@ -890,8 +890,6 @@ public class RequestHandler {
     
     
     //properties file
-    private static final String STRING_CONSTANTS_PROPERTIES_FILENAME = "conf/RestApiConstants.properties";
-    private static final String STRING_CONSTANTS_PROPERTIES_FILENAME = "src/main/resources/RestApiConstants.properties";
     private static final String STRING_CONSTANTS_PROPERTIES_FILENAME = "RestApiConstants.properties";
     private static Properties stringConstantsProperties = new Properties();
     private FileInputStream stringConstantsPropertiesFileInputStream= null;


### PR DESCRIPTION
Fixes the merge conflict in src/main/java/gsn/http/restapi/RequestHandler.java, which was causing a compile time error when I performed `ant build`
